### PR TITLE
remove callWithAttributes in favor of supertest 'send'

### DIFF
--- a/test/integration/v1/auth_login_test.js
+++ b/test/integration/v1/auth_login_test.js
@@ -65,19 +65,18 @@ describe('POST /auth/login', () => {
    * whitelist.
    */
   context('with blacklisted attributes', () => {
-    let attributes, reference;
+    let attributes, form;
 
     beforeEach(() => {
       attributes = _.difference(user.attributes,
         ['id', 'email', 'password', 'password_hash', 'token', 'token_id', 'created_at', 'updated_at']
       );
-      reference = factory.buildSync('forbiddenUser');
+      form = factory.buildSync('forbiddenUser').dataValues;
     });
 
     it('these attributes are filtered', done => {
-      api.callWithAttributes(attributes, reference,
-        api.auth.login(user)
-      )
+      api.auth.login(user)
+      .send(form)
       .expect(201)
       .end((err, res) => {
         if (err) { return done(err); }

--- a/test/integration/v1/change_email_test.js
+++ b/test/integration/v1/change_email_test.js
@@ -61,7 +61,7 @@ describe('PATCH /account/change_email', () => {
   });
 
   context('with blacklisted attributes', () => {
-    let attributes, reference;
+    let attributes, form;
 
     /*
      * The password can be ignored here, we already ensure
@@ -72,13 +72,12 @@ describe('PATCH /account/change_email', () => {
       attributes = _.difference(user.attributes,
         ['id', 'email', 'password', 'created_at', 'updated_at']
       );
-      reference = factory.buildSync('forbiddenUser');
+      form = factory.buildSync('forbiddenUser').dataValues;
     });
 
     it('these attributes are filtered', done => {
-      api.callWithAttributes(attributes, reference,
-        api.account(user).changeEmail()
-      )
+      api.account(user).changeEmail()
+      .send(form)
       .field('password', password)
       .field('new_email', NEW_EMAIL)
       .expect(204)

--- a/test/integration/v1/change_password_test.js
+++ b/test/integration/v1/change_password_test.js
@@ -86,19 +86,18 @@ describe('PATCH /account/change_password', () => {
    * Therefore, the password_hash is added to the whitelist of this test.
    */
   context('with blacklisted attributes', () => {
-    let attributes, reference;
+    let attributes, form;
 
     beforeEach(() => {
       attributes = _.difference(user.attributes,
         ['id', 'password', 'password_hash', 'created_at', 'updated_at']
       );
-      reference = factory.buildSync('forbiddenUser');
+      form = factory.buildSync('forbiddenUser').dataValues;
     });
 
     it('these attributes are filtered', done => {
-      api.callWithAttributes(attributes, reference,
-        api.account(user).changePassword()
-      )
+      api.account(user).changePassword()
+      .send(form)
       .field('old_password', oldPassword)
       .field('new_password', NEW_PASSWORD)
       .field('new_password_confirmation', NEW_PASSWORD)

--- a/test/integration/v1/update_profile_test.js
+++ b/test/integration/v1/update_profile_test.js
@@ -13,11 +13,10 @@ describe('PATCH /account/profile', () => {
   });
 
   it('updates the user profile', done => {
-    let reference = factory.buildSync('profile');
+    let form = factory.buildSync('profile').dataValues;
 
-    api.callWithAttributes(WHITELIST, reference,
-      api.account(user).updateProfile()
-    )
+    api.account(user).updateProfile()
+    .send(form)
     .expect(200)
     .end((err, res) => {
       if (err) { return done(err); }
@@ -25,7 +24,7 @@ describe('PATCH /account/profile', () => {
       let profile = format.timestamps(res.body.profile);
 
       expect(_.pick(profile, WHITELIST))
-        .to.deep.equal(_.pick(reference, WHITELIST));
+        .to.deep.equal(_.pick(form, WHITELIST));
       expect(user.getProfile())
         .to.eventually.have.property('dataValues')
         .that.deep.equals(profile)

--- a/test/support/api.js
+++ b/test/support/api.js
@@ -56,10 +56,3 @@ module.exports.account = function(user={}) {
     }
   };
 };
-
-module.exports.callWithAttributes = function(attributes, reference, action) {
-  attributes.forEach(attribute => {
-    action = action.field(attribute, reference.dataValues[attribute]);
-  });
-  return action;
-};


### PR DESCRIPTION
supertest allow us to do:

request
.send({ fullname: 'blabla' }