### PR TITLE
use specific version of docker-compose in circle ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   pre:
-    - sudo pip install -U docker-compose
+    - sudo pip install -U docker-compose==1.2.0
   services:
     - docker
 


### PR DESCRIPTION
Circle currently only offers docker 1.4.1 at the moment.

Therefore we need to use docker-compose 1.2.0.